### PR TITLE
Add physical remote listening and configurable fan speeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ fan:
     gdo2_pin: 12
     remote_id: [0x2D, 0xD4, 0x06, 0xCB, 0x00, 0xF7, 0xF2]
     # Optional:
+    # speed_count: 2
     # center_freq_mhz: 433.897
     # deviation_khz: 10
 ```
@@ -147,6 +148,7 @@ fan:
 | `gdo0_pin`        | Yes      | int          |           | GDO0 pin from CC1101 (used for TX/RX packet-complete signaling).             |
 | `gdo2_pin`        | Yes      | int          |           | GDO2 pin from CC1101 (can be -1 if unused).                                 |
 | `remote_id`       | Yes      | list[hex]    |           | 7-byte unique ID for your remote (see above).                               |
+| `speed_count`     | No       | int (2 or 3) | 3         | Set to `2` for LOW/HIGH fans, or `3` for LOW/MEDIUM/HIGH fans.               |
 | `center_freq_mhz` | No       | float        | 433.897    | Center frequency in MHz for RF transmission.                                |
 | `deviation_khz`   | No       | float        | 10         | Frequency deviation (spread) in kHz for FSK modulation.                     |
 
@@ -175,6 +177,10 @@ does not transmit an acknowledgement or current status. A missed RF command,
 a command from a different remote ID, or a fan power interruption can
 therefore leave the published state out of sync until the next matching
 command is received.
+
+For a two-speed fan, set `speed_count: 2`. ESPHome/Home Assistant will then
+expose two speeds, map speed 1 to the LOW RF command, and map speed 2 to HIGH.
+The default value of `3` retains the LOW/MEDIUM/HIGH behavior.
 
 ## Recent Improvements
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ fan:
 | `name`            | Yes      | string       |           | The name of the fan in Home Assistant.                                      |
 | `platform`        | Yes      | string       |           | Must be `quiet_cool`.                                                       |
 | `cs_pin`          | Yes      | int          |           | SPI chip select pin for CC1101.                                             |
-| `gdo0_pin`        | Yes      | int          |           | GDO0 pin from CC1101 (used for TX status).                                  |
+| `gdo0_pin`        | Yes      | int          |           | GDO0 pin from CC1101 (used for TX/RX packet-complete signaling).             |
 | `gdo2_pin`        | Yes      | int          |           | GDO2 pin from CC1101 (can be -1 if unused).                                 |
 | `remote_id`       | Yes      | list[hex]    |           | 7-byte unique ID for your remote (see above).                               |
 | `center_freq_mhz` | No       | float        | 433.897    | Center frequency in MHz for RF transmission.                                |
@@ -158,6 +158,23 @@ spi:
   mosi_pin: 23
   miso_pin: 19
 ```
+
+## Physical Remote State Tracking
+
+The component listens for the configured `remote_id` whenever it is not
+transmitting. A valid physical-remote command updates the ESPHome/Home
+Assistant fan power and speed state. The three repeated RF frames sent for a
+single button press are deduplicated automatically.
+
+Timed commands (1, 2, 4, 8, or 12 hours) also start a local countdown so the
+published state changes to off when the requested duration elapses. An `ON`
+or `OFF` command cancels that countdown.
+
+This is command tracking rather than feedback from the fan itself: the fan
+does not transmit an acknowledgement or current status. A missed RF command,
+a command from a different remote ID, or a fan power interruption can
+therefore leave the published state out of sync until the next matching
+command is received.
 
 ## Recent Improvements
 

--- a/components/quiet_cool/fan/__init__.py
+++ b/components/quiet_cool/fan/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_OUTPUT_ID,
 )
+from esphome.core import CORE
 from .. import quiet_cool_ns
 
 # Additional pin configuration keys
@@ -20,12 +21,20 @@ DEPENDENCIES = ["spi"]
 
 QuietCoolFan = quiet_cool_ns.class_("QuietCoolFan", cg.Component, fan.Fan, spi.SPIDevice)
 
+
+def validate_remote_id(value):
+    value = cv.ensure_list(cv.hex_uint8_t)(value)
+    if len(value) != 7:
+        raise cv.Invalid("remote_id must contain exactly 7 bytes")
+    return value
+
+
 CONFIG_SCHEMA = fan.fan_schema(QuietCoolFan).extend(
     {
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(QuietCoolFan),
         cv.Required(CONF_GDO0_PIN                      ): cv.uint8_t,
         cv.Required(CONF_GDO2_PIN                      ): cv.uint8_t,
-        cv.Required(CONF_REMOTE_ID                     ): cv.ensure_list(cv.hex_uint8_t),
+        cv.Required(CONF_REMOTE_ID                     ): validate_remote_id,
         cv.Optional(CONF_FREQ_MHZ     , default=433.897): cv.float_,
         cv.Optional(CONF_DEVIATION_KHZ, default=10.0   ): cv.float_
     }
@@ -33,6 +42,9 @@ CONFIG_SCHEMA = fan.fan_schema(QuietCoolFan).extend(
 
 
 async def to_code(config):
+    if CORE.is_esp32 and CORE.using_arduino:
+        cg.add_library("SPI", None)
+
     var = cg.new_Pvariable(config[CONF_OUTPUT_ID])  # type: QuietCoolFan
     await cg.register_component(var, config)
     await fan.register_fan(var, config)

--- a/components/quiet_cool/fan/__init__.py
+++ b/components/quiet_cool/fan/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_OSCILLATION_OUTPUT,
     CONF_OUTPUT,
     CONF_OUTPUT_ID,
+    CONF_SPEED_COUNT,
 )
 from esphome.core import CORE
 from .. import quiet_cool_ns
@@ -35,6 +36,7 @@ CONFIG_SCHEMA = fan.fan_schema(QuietCoolFan).extend(
         cv.Required(CONF_GDO0_PIN                      ): cv.uint8_t,
         cv.Required(CONF_GDO2_PIN                      ): cv.uint8_t,
         cv.Required(CONF_REMOTE_ID                     ): validate_remote_id,
+        cv.Optional(CONF_SPEED_COUNT  , default=3      ): cv.one_of(2, 3, int=True),
         cv.Optional(CONF_FREQ_MHZ     , default=433.897): cv.float_,
         cv.Optional(CONF_DEVIATION_KHZ, default=10.0   ): cv.float_
     }
@@ -53,4 +55,5 @@ async def to_code(config):
     cs_num = config[spi.CONF_CS_PIN]["number"]
     cg.add(var.set_pins(cs_num, config[CONF_GDO0_PIN], config[CONF_GDO2_PIN]))
     cg.add(var.set_remote_id(config[CONF_REMOTE_ID]))
+    cg.add(var.set_speed_count(config[CONF_SPEED_COUNT]))
     cg.add(var.set_frequencies(config[CONF_FREQ_MHZ], config[CONF_DEVIATION_KHZ]))

--- a/components/quiet_cool/fan/quiet_cool.cpp
+++ b/components/quiet_cool/fan/quiet_cool.cpp
@@ -24,7 +24,28 @@ namespace esphome {
         }
 
         fan::FanTraits QuietCoolFan::get_traits() {
-            return fan::FanTraits(false, true, false, 3);
+            return fan::FanTraits(false, true, false, this->speed_count_);
+        }
+
+        QuietCoolSpeed QuietCoolFan::to_radio_speed_(int speed) const {
+            if (speed <= 1)
+                return QUIETCOOL_SPEED_LOW;
+            if (this->speed_count_ == 2 || speed >= 3)
+                return QUIETCOOL_SPEED_HIGH;
+            return QUIETCOOL_SPEED_MEDIUM;
+        }
+
+        int QuietCoolFan::from_radio_speed_(QuietCoolSpeed speed) const {
+            switch (speed) {
+                case QUIETCOOL_SPEED_LOW:
+                    return 1;
+                case QUIETCOOL_SPEED_MEDIUM:
+                    return this->speed_count_ == 3 ? 2 : 0;
+                case QUIETCOOL_SPEED_HIGH:
+                    return this->speed_count_;
+                default:
+                    return 0;
+            }
         }
 
         void QuietCoolFan::loop() {
@@ -58,12 +79,7 @@ namespace esphome {
                 qcdur = QUIETCOOL_DURATION_OFF;
             } else {
                 qcdur = QUIETCOOL_DURATION_ON;
-                if (requested_speed <= 1)
-                    qcspd = QUIETCOOL_SPEED_LOW;
-                else if (requested_speed == 2)
-                    qcspd = QUIETCOOL_SPEED_MEDIUM;
-                else
-                    qcspd = QUIETCOOL_SPEED_HIGH;
+                qcspd = this->to_radio_speed_(requested_speed);
             }
 
             if (this->qc_ != nullptr)
@@ -71,7 +87,7 @@ namespace esphome {
 
             this->state = requested_state;
             if (requested_state)
-                this->speed = std::max(1, std::min(3, requested_speed));
+                this->speed = std::max(1, std::min(static_cast<int>(this->speed_count_), requested_speed));
             this->remote_timer_active_ = false;
 
             ESP_LOGV(TAG, "Post-update internal state: state=%s speed=%d",
@@ -84,20 +100,13 @@ namespace esphome {
                 this->state = false;
                 this->remote_timer_active_ = false;
             } else {
-                this->state = true;
-                switch (command.speed) {
-                    case QUIETCOOL_SPEED_LOW:
-                        this->speed = 1;
-                        break;
-                    case QUIETCOOL_SPEED_MEDIUM:
-                        this->speed = 2;
-                        break;
-                    case QUIETCOOL_SPEED_HIGH:
-                        this->speed = 3;
-                        break;
-                    default:
-                        return;
+                const int received_speed = this->from_radio_speed_(command.speed);
+                if (received_speed == 0) {
+                    ESP_LOGW(TAG, "Ignoring MEDIUM command configured for a 2-speed fan");
+                    return;
                 }
+                this->state = true;
+                this->speed = received_speed;
 
                 if (command.duration == QUIETCOOL_DURATION_ON) {
                     this->remote_timer_active_ = false;
@@ -114,6 +123,9 @@ namespace esphome {
             this->publish_state();
         }
 
-        void QuietCoolFan::dump_config() { LOG_FAN("", "QuietCool fan", this); }
+        void QuietCoolFan::dump_config() {
+            LOG_FAN("", "QuietCool fan", this);
+            ESP_LOGCONFIG(TAG, "  Speed count: %u", this->speed_count_);
+        }
     }  // namespace quiet_cool
 }  // namespace esphome

--- a/components/quiet_cool/fan/quiet_cool.cpp
+++ b/components/quiet_cool/fan/quiet_cool.cpp
@@ -1,6 +1,7 @@
 #include "quiet_cool.h"
 #include "esphome/core/log.h"
 #include "quietcool.h"
+#include <algorithm>
 
 namespace esphome {
     namespace quiet_cool {
@@ -26,41 +27,91 @@ namespace esphome {
             return fan::FanTraits(false, true, false, 3);
         }
 
+        void QuietCoolFan::loop() {
+            if (this->qc_ != nullptr) {
+                QuietCoolCommand command{};
+                if (this->qc_->receive(command))
+                    this->apply_received_command_(command);
+            }
+
+            if (this->remote_timer_active_ &&
+                static_cast<int32_t>(millis() - this->remote_off_at_) >= 0) {
+                this->remote_timer_active_ = false;
+                this->state = false;
+                ESP_LOGI(TAG, "Remote timer elapsed; publishing fan OFF");
+                this->publish_state();
+            }
+        }
+
         void QuietCoolFan::control(const fan::FanCall &call) {
-            float inc_speed = call.get_speed().value_or(-1.0f);
-            ESP_LOGD(TAG, "Control called: state=%s, speed=%s", 
+            const int requested_speed = call.get_speed().value_or(this->speed > 0 ? this->speed : 1);
+            const bool requested_state = call.get_state().value_or(this->state);
+            ESP_LOGD(TAG, "Control called: state=%s, speed=%d%s",
                      call.get_state().has_value() ? (*call.get_state() ? "ON" : "OFF") : "<unchanged>",
-                     call.get_speed().has_value() ? (std::to_string(inc_speed)).c_str() : "<unchanged>");
-            bool old_state = this->state;
-            if (call.get_state().has_value())
-                this->state = *call.get_state();
+                     requested_speed, call.get_speed().has_value() ? "" : " (unchanged)");
 
             QuietCoolSpeed qcspd = QUIETCOOL_SPEED_LOW;
-            QuietCoolDuration qcdur = QUIETCOOL_DURATION_ON;
-            if (call.get_speed().has_value()) {
-                this->speed_ = *call.get_speed();
-                if (this->speed_ < 0.5) qcdur = QUIETCOOL_DURATION_OFF;
-                else if (this->speed_ < 1.5) qcspd = QUIETCOOL_SPEED_LOW;
-                else if (this->speed_ < 2.5) qcspd = QUIETCOOL_SPEED_MEDIUM;
-                else if (this->speed_ < 3.5) qcspd = QUIETCOOL_SPEED_HIGH;
+            QuietCoolDuration qcdur;
+            if (!requested_state) {
+                // The captured physical remote uses B0 for OFF.
+                qcspd = QUIETCOOL_SPEED_HIGH;
+                qcdur = QUIETCOOL_DURATION_OFF;
             } else {
-		qcdur = QUIETCOOL_DURATION_OFF;
-	    }
-            if (this->qc_) this->qc_->send(qcspd, qcdur);
+                qcdur = QUIETCOOL_DURATION_ON;
+                if (requested_speed <= 1)
+                    qcspd = QUIETCOOL_SPEED_LOW;
+                else if (requested_speed == 2)
+                    qcspd = QUIETCOOL_SPEED_MEDIUM;
+                else
+                    qcspd = QUIETCOOL_SPEED_HIGH;
+            }
 
+            if (this->qc_ != nullptr)
+                this->qc_->send(qcspd, qcdur);
 
-            ESP_LOGV(TAG, "Post-update internal state: state=%s speed=%s", 
-                     (this->state ? "ON" : "OFF"),
-                     (std::to_string(this->speed_)).c_str());
+            this->state = requested_state;
+            if (requested_state)
+                this->speed = std::max(1, std::min(3, requested_speed));
+            this->remote_timer_active_ = false;
 
-            this->write_state_();
+            ESP_LOGV(TAG, "Post-update internal state: state=%s speed=%d",
+                     this->state ? "ON" : "OFF", this->speed);
             this->publish_state();
         }
 
-        void QuietCoolFan::write_state_() {
-            ESP_LOGVV(TAG, "write_state_: driving pins: state=%s ", 
-                      (this->state ? "ON" : "OFF"));
-            ESP_LOGVV(TAG, "write_state_: output calls completed");
+        void QuietCoolFan::apply_received_command_(const QuietCoolCommand &command) {
+            if (command.duration == QUIETCOOL_DURATION_OFF) {
+                this->state = false;
+                this->remote_timer_active_ = false;
+            } else {
+                this->state = true;
+                switch (command.speed) {
+                    case QUIETCOOL_SPEED_LOW:
+                        this->speed = 1;
+                        break;
+                    case QUIETCOOL_SPEED_MEDIUM:
+                        this->speed = 2;
+                        break;
+                    case QUIETCOOL_SPEED_HIGH:
+                        this->speed = 3;
+                        break;
+                    default:
+                        return;
+                }
+
+                if (command.duration == QUIETCOOL_DURATION_ON) {
+                    this->remote_timer_active_ = false;
+                } else {
+                    const uint32_t duration_ms =
+                        static_cast<uint32_t>(command.duration) * 60UL * 60UL * 1000UL;
+                    this->remote_off_at_ = millis() + duration_ms;
+                    this->remote_timer_active_ = true;
+                }
+            }
+
+            ESP_LOGI(TAG, "Publishing physical remote state: %s, speed %d, command 0x%02X",
+                     this->state ? "ON" : "OFF", this->speed, command.code);
+            this->publish_state();
         }
 
         void QuietCoolFan::dump_config() { LOG_FAN("", "QuietCool fan", this); }

--- a/components/quiet_cool/fan/quiet_cool.h
+++ b/components/quiet_cool/fan/quiet_cool.h
@@ -31,16 +31,20 @@ namespace esphome {
 		this->center_freq_mhz = center_freq_mhz;
 		this->deviation_khz = deviation_khz;
 	    }
+            void set_speed_count(uint8_t speed_count) { this->speed_count_ = speed_count; }
 
         protected:
             void control(const fan::FanCall &call) override;
             void apply_received_command_(const QuietCoolCommand &command);
+            QuietCoolSpeed to_radio_speed_(int speed) const;
+            int from_radio_speed_(QuietCoolSpeed speed) const;
         private:
             std::unique_ptr<QuietCool> qc_;
 
             uint8_t csn_pin_{};
             uint8_t gdo0_pin_{};
             uint8_t gdo2_pin_{};
+	    uint8_t speed_count_{3};
 	    float center_freq_mhz{433.897};
 	    float deviation_khz{10};
             bool pins_set_{false};

--- a/components/quiet_cool/fan/quiet_cool.h
+++ b/components/quiet_cool/fan/quiet_cool.h
@@ -19,6 +19,7 @@ namespace esphome {
             void dump_config() override;
             fan::FanTraits get_traits() override;
             void setup() override;  // initialise radio
+            void loop() override;
             float get_setup_priority() const override { return setup_priority::BUS; }
             void set_pins(uint8_t csn, uint8_t gdo0, uint8_t gdo2) {
                 this->csn_pin_ = csn;
@@ -26,14 +27,14 @@ namespace esphome {
                 this->gdo2_pin_ = gdo2;
                 this->pins_set_ = true;
             }
-	    void set_frequencies(float center_freq_mhz, float devation_khz) {
+	    void set_frequencies(float center_freq_mhz, float deviation_khz) {
 		this->center_freq_mhz = center_freq_mhz;
 		this->deviation_khz = deviation_khz;
 	    }
 
         protected:
             void control(const fan::FanCall &call) override;
-            void write_state_();
+            void apply_received_command_(const QuietCoolCommand &command);
         private:
             std::unique_ptr<QuietCool> qc_;
 
@@ -42,8 +43,9 @@ namespace esphome {
             uint8_t gdo2_pin_{};
 	    float center_freq_mhz{433.897};
 	    float deviation_khz{10};
-            float speed_{0.0f};
             bool pins_set_{false};
+            bool remote_timer_active_{false};
+            uint32_t remote_off_at_{0};
             std::array<uint8_t, 7> remote_id_{{0x2D, 0xD4, 0x06, 0xCB, 0x00, 0xF7, 0xF2}};
         public:
             void set_remote_id(const std::vector<uint8_t> &remote_id) {

--- a/components/quiet_cool/fan/quietcool.cpp
+++ b/components/quiet_cool/fan/quietcool.cpp
@@ -12,9 +12,10 @@ static const char *TAG = "quietcool";
 
 const uint8_t SYNC[] = {0x15, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa};
 #define SYNC_LEN (sizeof(SYNC))
-#define REMOTE_ID_LEN (sizeof(REMOTE_ID))
 
 #define CMD_CODE_LEN 2
+
+QuietCool *QuietCool::active_receiver_ = nullptr;
 
 // Commands are structured like this:
 // LOW: 0x90
@@ -77,6 +78,166 @@ void QuietCool::sendRawData(const uint8_t* data, size_t len) {
     delay(10);
 }
 
+void QuietCool::configureTransmit() {
+    // Preserve the working packet-mode transmitter. The captured QuietCool
+    // preamble/sync bytes are part of the FIFO payload, not CC1101 framing.
+    ELECHOUSE_cc1101.setSidle();
+    ELECHOUSE_cc1101.setSyncMode(0);
+    ELECHOUSE_cc1101.setLengthConfig(0);
+    ELECHOUSE_cc1101.setPacketLength(20);
+    ELECHOUSE_cc1101.setAppendStatus(false);
+}
+
+void QuietCool::configureReceive() {
+    // Use the first two bytes of the configured remote ID as the hardware sync
+    // word. The FIFO then contains the other five ID bytes and two command
+    // bytes, allowing the CC1101 to establish both bit and byte alignment.
+    ELECHOUSE_cc1101.setSidle();
+    ELECHOUSE_cc1101.setSyncWord(remote_id[0], remote_id[1]);
+    ELECHOUSE_cc1101.setSyncMode(2);  // 16/16 sync word, no carrier-sense gate
+    ELECHOUSE_cc1101.setWhiteData(false);
+    ELECHOUSE_cc1101.setManchester(false);
+    ELECHOUSE_cc1101.setPktFormat(0);
+    ELECHOUSE_cc1101.setCrc(false);
+    ELECHOUSE_cc1101.setLengthConfig(0);
+    ELECHOUSE_cc1101.setPacketLength(RX_PAYLOAD_LEN);
+    ELECHOUSE_cc1101.setPQT(0);
+    ELECHOUSE_cc1101.setAdrChk(0);
+    ELECHOUSE_cc1101.setAppendStatus(true);
+}
+
+void QuietCool::startListening() {
+    if (!initialized_)
+        return;
+
+    listening_ = false;
+    noInterrupts();
+    packet_ready_ = false;
+    interrupts();
+
+    configureReceive();
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFRX);
+    ELECHOUSE_cc1101.SetRx();
+    listening_ = true;
+    ESP_LOGD(TAG, "Listening for remote ID %02X:%02X:%02X:%02X:%02X:%02X:%02X",
+             remote_id[0], remote_id[1], remote_id[2], remote_id[3],
+             remote_id[4], remote_id[5], remote_id[6]);
+}
+
+void QuietCool::restartReceiver() {
+    listening_ = false;
+    ELECHOUSE_cc1101.setSidle();
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFRX);
+    ELECHOUSE_cc1101.SetRx();
+    listening_ = true;
+}
+
+void IRAM_ATTR QuietCool::handleGdo0Interrupt() {
+    QuietCool *receiver = active_receiver_;
+    if (receiver != nullptr && receiver->listening_)
+        receiver->packet_ready_ = true;
+}
+
+int8_t QuietCool::decodeRssi(uint8_t raw_rssi) {
+    const int16_t signed_rssi = raw_rssi >= 128 ? raw_rssi - 256 : raw_rssi;
+    return static_cast<int8_t>(signed_rssi / 2 - 74);
+}
+
+bool QuietCool::decodePayload(const uint8_t *payload, QuietCoolCommand &command) const {
+    if (memcmp(payload, remote_id + 2, REMOTE_ID_LEN - 2) != 0) {
+        ESP_LOGV(TAG, "Ignoring frame with non-matching remote ID suffix");
+        return false;
+    }
+
+    const uint8_t command_code = payload[REMOTE_ID_LEN - 2];
+    const uint8_t repeated_code = payload[REMOTE_ID_LEN - 1];
+    if (command_code != repeated_code) {
+        ESP_LOGW(TAG, "Ignoring frame with mismatched command bytes: %02X != %02X",
+                 command_code, repeated_code);
+        return false;
+    }
+
+    const uint8_t speed_code = command_code & 0xF0;
+    switch (speed_code) {
+        case QUIETCOOL_SPEED_LOW:
+        case QUIETCOOL_SPEED_MEDIUM:
+        case QUIETCOOL_SPEED_HIGH:
+            command.speed = static_cast<QuietCoolSpeed>(speed_code);
+            break;
+        default:
+            // 0x66 is a setup/pre-command and does not represent fan state.
+            ESP_LOGV(TAG, "Ignoring non-state command 0x%02X", command_code);
+            return false;
+    }
+
+    const uint8_t duration_code = command_code & 0x0F;
+    switch (duration_code) {
+        case QUIETCOOL_DURATION_1H:
+        case QUIETCOOL_DURATION_2H:
+        case QUIETCOOL_DURATION_4H:
+        case QUIETCOOL_DURATION_8H:
+        case QUIETCOOL_DURATION_12H:
+        case QUIETCOOL_DURATION_ON:
+        case QUIETCOOL_DURATION_OFF:
+            command.duration = static_cast<QuietCoolDuration>(duration_code);
+            break;
+        default:
+            ESP_LOGW(TAG, "Ignoring command with invalid duration: 0x%02X", command_code);
+            return false;
+    }
+
+    command.code = command_code;
+    return true;
+}
+
+bool QuietCool::receive(QuietCoolCommand &command) {
+    if (!initialized_ || !packet_ready_)
+        return false;
+
+    noInterrupts();
+    packet_ready_ = false;
+    interrupts();
+
+    const uint8_t rx_bytes_status = ELECHOUSE_cc1101.SpiReadStatus(CC1101_RXBYTES);
+    if ((rx_bytes_status & 0x80) != 0) {
+        ESP_LOGW(TAG, "CC1101 RX FIFO overflow; restarting receiver");
+        restartReceiver();
+        return false;
+    }
+
+    const uint8_t available = rx_bytes_status & 0x7F;
+    constexpr size_t expected = RX_PAYLOAD_LEN + RX_STATUS_LEN;
+    if (available < expected) {
+        ESP_LOGW(TAG, "Incomplete RX frame: got %u bytes, expected %u",
+                 available, static_cast<unsigned>(expected));
+        restartReceiver();
+        return false;
+    }
+
+    uint8_t frame[expected];
+    ELECHOUSE_cc1101.SpiReadBurstReg(CC1101_RXFIFO, frame, expected);
+    restartReceiver();
+
+    command.rssi_dbm = decodeRssi(frame[RX_PAYLOAD_LEN]);
+    command.lqi = frame[RX_PAYLOAD_LEN + 1] & 0x7F;
+    if (!decodePayload(frame, command))
+        return false;
+
+    const uint32_t now = millis();
+    const bool duplicate = command.code == last_rx_code_ &&
+                           static_cast<uint32_t>(now - last_rx_at_) < RX_DEDUP_WINDOW_MS;
+    last_rx_code_ = command.code;
+    last_rx_at_ = now;
+    if (duplicate) {
+        ESP_LOGV(TAG, "Ignoring repeated remote frame 0x%02X", command.code);
+        return false;
+    }
+
+    ESP_LOGI(TAG, "Received remote command 0x%02X (RSSI %d dBm, LQI %u)",
+             command.code, command.rssi_dbm, command.lqi);
+    return true;
+}
+
 void QuietCool::sendPacket(const uint8_t cmd_code) {
     const uint8_t padding_len = 2;
     uint8_t full_cmd[SYNC_LEN + 7 + CMD_CODE_LEN+padding_len];
@@ -94,7 +255,8 @@ void QuietCool::sendPacket(const uint8_t cmd_code) {
 
 const uint8_t QuietCool::getCommand(QuietCoolSpeed speed, QuietCoolDuration duration) {
     ESP_LOGD(TAG, "getCommand got: speed=0x%02x, duration=0x%02x", speed, duration);
-    const uint8_t off = QUIETCOOL_DURATION_OFF | QUIETCOOL_SPEED_LOW;
+    const uint8_t off = static_cast<uint8_t>(QUIETCOOL_DURATION_OFF) |
+                        static_cast<uint8_t>(QUIETCOOL_SPEED_LOW);
     switch (speed) {
     case QUIETCOOL_SPEED_HIGH:
     case QUIETCOOL_SPEED_MEDIUM:
@@ -118,7 +280,7 @@ const uint8_t QuietCool::getCommand(QuietCoolSpeed speed, QuietCoolDuration dura
 	ESP_LOGD(TAG, "unknown duration: 0x%02x", duration);
 	return off;
     }
-    uint8_t result = speed | duration;
+    uint8_t result = static_cast<uint8_t>(speed) | static_cast<uint8_t>(duration);
     ESP_LOGD(TAG, "Sending speed=0x%02x, duration=0x%02x: 0x%02x", speed, duration, result);
     return result;
 }
@@ -180,6 +342,9 @@ bool QuietCool::initCC1101() {
     ESP_LOGI(TAG, "Setting deviaion to %f kHz.  That's a total spread of %f kHz", deviation_khz, 2*deviation_khz);
     ELECHOUSE_cc1101.setDeviation(deviation_khz);
     ELECHOUSE_cc1101.setDRate(2.398);
+    // Wide enough for this 2-FSK signal and typical module frequency error,
+    // while substantially improving receive sensitivity over the reset maximum.
+    ELECHOUSE_cc1101.setRxBW(100.0);
     ELECHOUSE_cc1101.setSyncMode(0);
     ELECHOUSE_cc1101.setWhiteData(false);
     ELECHOUSE_cc1101.setManchester(false);
@@ -202,14 +367,29 @@ void QuietCool::begin() {
         ESP_LOGE(TAG, "CC1101 not detected");
         return;
     }
+    initialized_ = true;
+    active_receiver_ = this;
+    attachInterrupt(digitalPinToInterrupt(gdo0_pin), QuietCool::handleGdo0Interrupt, FALLING);
+    startListening();
     ESP_LOGI(TAG, "CC1101 ready");
 }
 
 void QuietCool::send(QuietCoolSpeed speed, QuietCoolDuration duration) {
+    if (!initialized_) {
+        ESP_LOGW(TAG, "Cannot transmit before CC1101 initialization");
+        return;
+    }
+
     ESP_LOGI(TAG, "send(0x%02x, %0x%02x)", speed, duration);
     const uint8_t cmd_code = getCommand(speed, duration);
     ESP_LOGI(TAG, "cmd=%02x ", cmd_code);
+    listening_ = false;
+    noInterrupts();
+    packet_ready_ = false;
+    interrupts();
+    configureTransmit();
     sendPacket(cmd_code);
+    startListening();
 }
 
 }  // namespace quiet_cool

--- a/components/quiet_cool/fan/quietcool.h
+++ b/components/quiet_cool/fan/quietcool.h
@@ -36,9 +36,20 @@ enum QuietCoolDuration {
     QUIETCOOL_DURATION_LAST
 };
 
+struct QuietCoolCommand {
+    QuietCoolSpeed speed;
+    QuietCoolDuration duration;
+    uint8_t code;
+    int8_t rssi_dbm;
+    uint8_t lqi;
+};
+
 class QuietCool {
   private:
-    static constexpr uint8_t TO_BIT(char c) { return (c == '1') ? 1 : 0; }
+    static constexpr size_t REMOTE_ID_LEN = 7;
+    static constexpr size_t RX_PAYLOAD_LEN = REMOTE_ID_LEN - 2 + 2;
+    static constexpr size_t RX_STATUS_LEN = 2;
+    static constexpr uint32_t RX_DEDUP_WINDOW_MS = 350;
 
     uint8_t csn_pin;
     uint8_t gdo0_pin;
@@ -49,20 +60,33 @@ class QuietCool {
     uint8_t remote_id[7];
     float   center_freq_mhz;
     float   deviation_khz;
+    bool initialized_{false};
+    volatile bool listening_{false};
+    volatile bool packet_ready_{false};
+    uint8_t last_rx_code_{0};
+    uint32_t last_rx_at_{0};
+
+    static QuietCool *active_receiver_;
+    static void handleGdo0Interrupt();
 
     bool initCC1101();
     uint8_t readChipVersion();
-    void processBitsFromBytes(const uint8_t* bytes, size_t byte_len, bool send_to_pin);
     void sendRawData(const uint8_t* data, size_t len);
     void sendPacket(const uint8_t cmd_code);
     const uint8_t getCommand(QuietCoolSpeed speed, QuietCoolDuration duration);
     void logBits(const uint8_t* data, size_t len);
-    // REMOTE_ID is now the name for the unique remote identifier
+    void configureTransmit();
+    void configureReceive();
+    void startListening();
+    void restartReceiver();
+    bool decodePayload(const uint8_t *payload, QuietCoolCommand &command) const;
+    static int8_t decodeRssi(uint8_t raw_rssi);
 
   public:
     QuietCool(uint8_t csn, uint8_t gdo0, uint8_t gdo2, uint8_t sck, uint8_t miso, uint8_t mosi, const uint8_t* remote_id_in, float freq_mhz, float deviation_khz);
     void begin();
     void send(QuietCoolSpeed speed, QuietCoolDuration duration);
+    bool receive(QuietCoolCommand &command);
 };
 
 }  // namespace quiet_cool

--- a/quietcool-fan-example.yaml
+++ b/quietcool-fan-example.yaml
@@ -49,3 +49,4 @@ fan:
     gdo0_pin: 13
     gdo2_pin: 12
     remote_id: [0x2D, 0xD4, 0x06, 0xCB, 0x00, 0xF7, 0xF2]
+    # speed_count: 2  # Use 2 for fans that support LOW/HIGH only; default is 3.


### PR DESCRIPTION
## Summary

Add half-duplex receive support so the ESPHome/CC1101 remote listens for the configured physical remote whenever it is not transmitting, then publishes matching power and speed commands back to ESPHome/Home Assistant.

Also add a `speed_count` option so both LOW/HIGH and LOW/MEDIUM/HIGH QuietCool models expose the correct fan capabilities in Home Assistant.

This keeps Home Assistant synchronized when the original handheld remote is used. The receive implementation has now been tested successfully with the physical remote and CC1101 hardware.

## Why

The component previously transmitted QuietCool commands but left the CC1101 idle afterward. As a result, using the original remote changed the fan without updating the ESPHome fan entity.

QuietCool RF is one-way: the fan does not acknowledge commands or broadcast its actual state. Listening for the original remote is therefore the best available way to track external commands. This is command-state tracking rather than authoritative feedback, and that limitation is documented.

QuietCool models also differ in their supported speeds. Hard-coding three speeds causes Home Assistant to advertise a nonexistent MEDIUM setting for LOW/HIGH-only fans, and maps the second Home Assistant speed to the wrong RF command.

## Changes

### CC1101 receive path

- Keep the CC1101 in RX mode whenever it is not transmitting.
- Switch explicitly between the existing working TX profile and a receive-specific packet profile.
- Use the first two configured remote-ID bytes as the CC1101 hardware sync word.
- Receive a fixed seven-byte payload containing the remaining five remote-ID bytes and two duplicated command bytes.
- Use the GDO0 packet-complete falling edge only to set an ISR-safe flag; all SPI and ESPHome work remains in the normal component loop.
- Read the fixed-length RX FIFO directly because the bundled generic `ReceiveData()` expects a variable-length byte that the physical remote does not transmit.
- Recover from incomplete frames and RX FIFO overflow by flushing and restarting RX.
- Restore RX automatically after every transmitted command.
- Configure a 100 kHz receive bandwidth to cover the 2-FSK signal and expected module frequency error without leaving the receiver at its widest/noisiest setting.
- Log decoded command, RSSI, and LQI for hardware diagnostics.

### Frame validation and filtering

- Validate all seven configured remote-ID bytes: two in hardware sync and five in software.
- Require the two command bytes in the frame to match.
- Accept only known QuietCool speed and duration encodings.
- Ignore the non-state `0x66` pre/setup command.
- Deduplicate the repeated RF frames generated by one button press.

### ESPHome state synchronization

- Add a non-blocking component `loop()` that consumes received commands.
- Publish physical-remote power and speed through the actual ESPHome `Fan::state` and `Fan::speed` fields.
- Track 1, 2, 4, 8, and 12-hour remote commands locally and publish OFF when their expected duration expires.
- Cancel the local timer on ON, OFF, or ESPHome-originated commands.

### Two- and three-speed fan models

- Add optional `speed_count`, restricted to `2` or `3` and defaulting to `3` for backward compatibility.
- Report the configured speed count through ESPHome fan traits so Home Assistant exposes the correct entity controls.
- For `speed_count: 2`, map Home Assistant speed 1 to LOW and speed 2 to HIGH; never transmit MEDIUM.
- For `speed_count: 3`, retain the existing LOW/MEDIUM/HIGH mapping.
- Map a received HIGH command to speed 2 or 3 according to the configured model.
- Ignore a received MEDIUM command for a two-speed model instead of publishing an invalid entity speed.
- Log the configured speed count during component configuration output.

### Existing control-path corrections included in this branch

- Register the Arduino `SPI` library during ESPHome code generation so the bundled CC1101 driver links reliably on ESP32 Arduino builds.
- Fix the `set_frequencies()` deviation parameter typo that previously caused a self-assignment and ignored the configured deviation.
- Use the ESPHome fan base-class speed field rather than a separate shadow `speed_` value.
- Preserve the current speed for state-only calls and default safely to low when no speed has been selected.
- Emit the captured physical-remote OFF encoding (`0xB0`) instead of accidentally mapping state-only calls to OFF.
- Clamp published speeds to the configured supported range.
- Add explicit enum casts to remove deprecated mixed-enum bitwise-operation warnings.

### Configuration and documentation

- Require `remote_id` to contain exactly seven bytes instead of accepting arbitrary list lengths.
- Document `speed_count`, including the LOW/HIGH mapping.
- Document GDO0's RX/TX packet-complete role.
- Document physical-remote tracking, timed-command behavior, deduplication, and the one-way-state limitation.

Example for a LOW/HIGH fan:

```yaml
fan:
  - platform: quiet_cool
    name: QuietCool fan
    cs_pin: 15
    gdo0_pin: 13
    gdo2_pin: 12
    remote_id: [0x2D, 0xD4, 0x06, 0xCB, 0x00, 0xF7, 0xF2]
    speed_count: 2
```

## Validation

- ESPHome 2026.6.5 configuration validation passed.
- Two-speed configuration validation passed.
- Unsupported `speed_count` validation passed (`4` is rejected; only `2` and `3` are accepted).
- Invalid remote-ID length validation passed.
- Full ESP32 Arduino firmware compile and final link passed with the default three-speed configuration.
- Full ESP32 Arduino firmware compile and final link passed with `speed_count: 2`.
- `git diff --check` passed.
- Physical CC1101/QuietCool remote test passed: commands from the handheld remote were received and reflected in the ESPHome fan state.
